### PR TITLE
Fix typo in category

### DIFF
--- a/package-list.json
+++ b/package-list.json
@@ -23,5 +23,5 @@
     "package-id": "hl7.fhir.uv.ihe-sdc-ecc",
     "title": "IHE SDC/eCC on FHIR",
     "canonical": "http://hl7.org/fhir/uv/ihe-sdc-ecc",
-    "category": "Orders and Observaitons"
+    "category": "Orders and Observations"
   }


### PR DESCRIPTION
It shows up on http://fhir.org/guides/registry -

![image](https://user-images.githubusercontent.com/110988/202703756-64511680-e9c0-43ba-a499-04fc8be180f3.png)
